### PR TITLE
Add Hand-Wave Access Method Support

### DIFF
--- a/src/access-api.ts
+++ b/src/access-api.ts
@@ -5,7 +5,8 @@
 import { ACCESS_API_ERROR_LIMIT, ACCESS_API_RETRY_INTERVAL, ACCESS_API_TIMEOUT } from "./settings.js";
 import { ALPNProtocol, AbortError, FetchError, Headers, type Request, type RequestOptions, type Response, context, timeoutSignal } from "@adobe/fetch";
 import type { AccessApiResponse, AccessBootstrapConfig, AccessControllerConfig, AccessDeviceConfig, AccessDeviceConfigPayload, AccessDoorConfig,
-  AccessFloorConfig } from "./access-types.js";
+  AccessFloorConfig, AccessDeviceMethodPayload } from "./access-types.js";
+import { AccessMethod } from "./access-types.js";
 import type { AccessLogging } from "./access-logging.js";
 import { EventEmitter } from "node:events";
 import WebSocket from "ws";
@@ -1141,5 +1142,70 @@ export class AccessApi extends EventEmitter {
 
       return this.address;
     }
+  }
+
+  /**
+   * Update a reader device's access method.
+   *
+   * @param device - The reader device to update.
+   * @param accessMethod - The access method to set (NFC or hand-wave).
+   *
+   * @returns Returns a promise that will resolve to true if successful, and false otherwise.
+   */
+  public async setReaderAccessMethod(device: AccessDeviceConfig, accessMethod: AccessMethod): Promise<boolean> {
+    this.log.info("Setting reader access method for %s to %s", device.alias ?? device.model, accessMethod);
+    // No device object, we're done.
+    if(!device) {
+      this.log.error("No device object provided");
+      return false;
+    }
+
+    // Log us in if needed.
+    if(!(await this.loginController())) {
+      this.log.error("Failed to login to controller");
+      return false;
+    }
+
+    // Check if this is a reader device with hand-wave capability
+    if(!device.capabilities?.includes("is_reader")) {
+      this.log.error("%s: Device is not a reader.", this.getFullName(device));
+      return false;
+    }
+
+    // Check for hand-wave capability if we're trying to enable it
+    if(accessMethod === AccessMethod.HAND_WAVE && !device.capabilities?.includes("hand_wave")) {
+      this.log.error("%s: Device does not support hand-wave access method.", this.getFullName(device));
+      return false;
+    }
+
+    // Prepare the payload based on the Python implementation
+    const payload = [
+      {
+        key: "nfc",
+        tag: "open_door_mode",
+        value: accessMethod === AccessMethod.NFC ? "yes" : "no"
+      },
+      {
+        key: "wave",
+        tag: "open_door_mode",
+        value: accessMethod === AccessMethod.HAND_WAVE ? "yes" : "no"
+      }
+    ];
+
+    this.log.debug("%s: Setting access method to %s", this.getFullName(device), accessMethod);
+
+    // Update Access with the new configuration using the correct endpoint
+    const response = await this.retrieve(this.getApiEndpoint("device") + "/" + device.unique_id + "/configs", {
+      body: JSON.stringify(payload),
+      method: "PUT"
+    });
+
+    if(!response?.ok) {
+      this.log.error("%s: Unable to update access method: %s.", this.getFullName(device), response?.status);
+      return false;
+    }
+
+    this.log.info("Successfully set access method for %s", device.device_type);
+    return true;
   }
 }

--- a/src/access-types.ts
+++ b/src/access-types.ts
@@ -368,3 +368,17 @@ export type AccessDoorConfigPayload = DeepPartial<AccessDoorConfigInterface>;
 export type AccessFloorConfig = Readonly<AccessFloorConfigInterface>;
 /** @interface */
 export type AccessFloorConfigPayload = DeepPartial<AccessFloorConfigInterface>;
+
+// Reader access method types
+export enum AccessMethod {
+  NFC = "nfc",
+  HAND_WAVE = "hand-wave"
+}
+
+export interface AccessDeviceMethodPayload {
+  access_method: AccessMethod;
+  configs: {
+    key: string;
+    value: string;
+  }[];
+}


### PR DESCRIPTION
Reference issue: https://github.com/hjdhjd/homebridge-unifi-access/issues/49

Reference pull request from `hjdhjd/homebridge-unifi-access`: https://github.com/hjdhjd/homebridge-unifi-access/pull/52

Disclaimer: While this change may not measure up to the maintainer's standards, it does offer a tested and working prototype that addresses the issue above. I hope this helps with the final implementation in the future.

# Add Hand-Wave Access Method Support

<img src="https://github.com/user-attachments/assets/a8ec5eb6-cfe8-4e7e-8688-34527d0b6bb1" width="400">

<img src="https://github.com/user-attachments/assets/94712432-29f6-405e-b78c-0c404ecc29e2" width="230">

This PR adds support for the hand-wave access method available on compatible UniFi Access readers. The implementation includes:

- New `AccessMethod` enum in `access-types.ts` to support both NFC and hand-wave methods
- Implementation of `setReaderAccessMethod()` in `AccessApi` class to configure reader access methods
- Proper capability checking to ensure hand-wave functionality is only enabled on supported devices
- API endpoint integration for updating reader configurations

## Technical Details
- Added new API endpoint handling for device configuration updates
- Implemented proper error handling and logging for access method changes
- Added capability validation to prevent enabling hand-wave on unsupported devices
- Configuration payload structure matches UniFi Access controller expectations

## Testing
- Tested with UA-LITE and UA-G2-MINI reader models
- Verified proper capability detection and validation
- Confirmed successful switching between NFC and hand-wave modes
- Validated error handling for unsupported devices

## Known Issues
The `AccessMethod` enum will likely need to be expanded to handle additional methods like `pin_code` `bt_tap` and `bt_button` but I didn't have the hardware to test these options.